### PR TITLE
remove SSH_AUTH_SOCK env var

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-export SSH_AUTH_SOCK=/root/.ssh/ssh-agent.sock
-echo $SSH_AUTH_SOCK


### PR DESCRIPTION
Since we are using [smooth-secrets](https://github.com/hasura/smooth-secrets-buildkite-plugin) plugin for setting up ssh keys, this plugin should not care about this. 