### PR TITLE
skip cleanup when skip_checkout is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All the things you need during a Buildkite checkout :butter: :kite:
 steps:
   - command: echo "Skips checking out Git project in checkout" 
     plugins:
-      - hasura/smooth-checkout#v1.0.1:
+      - hasura/smooth-checkout#v1.0.2:
           skip_checkout: true
 ```
 
@@ -17,7 +17,7 @@ steps:
 steps:
   - command: echo "Checks out repo at given ref"
     plugins:
-      - hasura/smooth-checkout#v1.0.1:
+      - hasura/smooth-checkout#v1.0.2:
           clone_url: https://github.com/<username>/<reponame>
           ref: <ref>
 ```

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+if [[ "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_SKIP_CHECKOUT" == "true" ]]; then
+    exit 0
+fi
+
 echo "--- :broom: Cleaning up workspace"
 echo "Removing directory: $WORKSPACE/$CLONE_DIR"
 sudo rm -rf "$WORKSPACE/$CLONE_DIR"


### PR DESCRIPTION
When using skip_checkout, the job was infinitely running by asking sudo password for rm operation in clean up. While sudo operation is something that we need to take care of separately, this PR at least avoids the need for the skip_checkout case. 