### PR TITLE
Make the checkout directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ steps:
 ## Setup & Cleanup
 Smooth Checkout also supports setting custom directories for your jobs and deleting the checkout
 directory after the job completes. `BUILDKITE_BUILD_CHECKOUT_PATH` is set to the
-directory specified by the `build_checkout_path` option.
+directory specified by the `build_checkout_path` option. For legacy reasons, the environment
+variable `WORKSPACE` is also set to the same value, but its usage is deprecated.
 ```yaml
 steps:
   - command: echo "Checks out repo to custom directory"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ All the things you need during a Buildkite checkout :butter: :kite:
 ### Repository-less builds
 ```yml
 steps:
-  - command: echo "Skips checking out Git project in checkout" 
+  - command: echo "Skips checking out Git project in checkout"
     plugins:
       - hasura/smooth-checkout#v3.1.0:
           skip_checkout: true
@@ -45,8 +45,10 @@ steps:
               - url: https://github.com/<username>/<repo_2>.git
                 ref: <ref>
 ```
-Unlike single repo checkouts, when checking out multiple repos, the working directory will be set to `$WOKRSPACE`, where all the repo checkouts have been done.
-In the above example, the contents of the working directory would be `repo_1/` and `repo_2/`.
+Unlike single repo checkouts, when checking out multiple repos, they will each be checked out in
+subdirectories of `$BUILDKITE_BUILD_CHECKOUT_PATH` corresponding to the name of the repository
+(based on its URL). In the above example, the contents of the working directory would be `repo_1/`
+and `repo_2/`.
 
 You can also explicitly provide the path to an ssh identity file using the `ssh_key_path` config field:
 ```yaml
@@ -64,7 +66,8 @@ steps:
                 ssh_key_path: .ssh/key_2
 ```
 
-If you are using [smooth-secrets](https://github.com/hasura/smooth-secrets-buildkite-plugin) to configure ssh keys, you can do the following to easily set the `ssh_key_path`:
+If you are using [smooth-secrets](https://github.com/hasura/smooth-secrets-buildkite-plugin) to
+configure ssh keys, you can do the following to easily set the `ssh_key_path`:
 ```yaml
 steps:
   - command: echo "Checks out multiple git repositories"
@@ -75,10 +78,13 @@ steps:
               - url: git@github.com:<username>/<repo>.git
                 ssh_key_path: $$SECRETS_DIR/<key>
 ```
-where `<key>` is the value of [`key` field](https://github.com/hasura/smooth-secrets-buildkite-plugin#key-required-string) in smooth-secrets config with any `/` characters replaced by `-`.
+where `<key>` is the value of
+[`key` field](https://github.com/hasura/smooth-secrets-buildkite-plugin#key-required-string) in
+smooth-secrets config with any `/` characters replaced by `-`.
 
 ### Checking out repo from git mirrors
-You can attempt to fetch a git repository from git mirrors and fallback to using the original source repo in case of a failure while checking out from mirrors.
+You can attempt to fetch a git repository from git mirrors and fallback to using the original
+source repo in case of a failure while checking out from mirrors.
 ```yaml
 steps:
   - command: echo "Checks out repo from mirror (fall back to github in case of failure)"
@@ -92,9 +98,20 @@ steps:
 
 
 ## Setup & Cleanup
-Smooth Checkout sets up a workspace directory for your jobs in a non-conflicting fashion. Smooth Checkout achieves this by setting up a workspace directory at `$HOME/buildkite-checkouts/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID`. The workspace path is made available as `WORKSPACE` environment variable in command section.
-
-Smooth Checkout also takes care of cleaning up the workspace directory at the end of the Buildkite job.
+Smooth Checkout also supports setting custom directories for your jobs and deleting the checkout
+directory after the job completes. `BUILDKITE_BUILD_CHECKOUT_PATH` is set to the
+directory specified by the `build_checkout_path` option.
+```yaml
+steps:
+  - command: echo "Checks out repo to custom directory"
+    plugins:
+      - hasura/smooth-checkout#v3.1.0:
+          build_checkout_path: /tmp/${BUILDKITE_COMMIT}
+          delete_checkout: true
+          repos:
+            - config:
+              - url: git@github.com:<username>/<reponame>.git
+```
 
 ## Contributing
   - Fork this repo and clone on your machine:

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -42,13 +42,13 @@ get_repo_name() {
 
 setup_git_repo() {
   set +e
-  local CLONE_URL="$1"
+  local REPO_URL="$1"
   local CHECKOUT_REF="$2"
   local SSH_KEY_PATH="$3"
   local CLONE_DIR="$4"
 
   echo " :::: local clone location = '$CLONE_DIR'"
-  echo " :::: git remote url = '$CLONE_URL'"
+  echo " :::: git remote url = '$REPO_URL'"
   echo " :::: ssh key path = '$SSH_KEY_PATH'"
 
   if [[ -n "$SSH_KEY_PATH" ]]; then
@@ -57,8 +57,15 @@ setup_git_repo() {
   fi
 
   mkdir -p "${CLONE_DIR}" && cd "${CLONE_DIR}"
-  git clone --no-checkout "$CLONE_URL" .
-  local EXIT_STATUS=$?
+  if [[ -d ".git" ]]; then
+    echo "Git repository already exists. Just setting remote url"
+    git remote set-url origin "${REPO_URL}"
+    local EXIT_STATUS=$?
+  else
+    echo "Cloning ${REPO_URL}"
+    git clone ${BUILDKITE_GIT_CLONE_FLAGS} --no-checkout -- "$REPO_URL" .
+    local EXIT_STATUS=$?
+  fi
   if [[ $EXIT_STATUS -ne 0 ]]; then
     return $EXIT_STATUS
   fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -82,7 +82,7 @@ setup_git_repo() {
   else
     echo "Checking out ref: $CHECKOUT_REF"
     git fetch --force origin "$CHECKOUT_REF" && \
-    git checkout --quiet --force "$CHECKOUT_REF"
+    git checkout --quiet --force FETCH_HEAD
     local EXIT_STATUS=$?
     if [[ $EXIT_STATUS -ne 0 ]]; then
       return $EXIT_STATUS

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -9,8 +9,8 @@ if [[ "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_SKIP_CHECKOUT" == "true" ]]; then
 fi
 
 echo "--- :open_file_folder: Setting up workspace"
-echo "Creating directory: $WORKSPACE"
-mkdir -p "$WORKSPACE" && cd "$WORKSPACE"
+echo "Creating directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
+mkdir -p "$BUILDKITE_BUILD_CHECKOUT_PATH" && cd "$BUILDKITE_BUILD_CHECKOUT_PATH"
 echo "Setup completed successfully."
 
 echo "--- :key: Setting up git and ssh"
@@ -45,21 +45,19 @@ setup_git_repo() {
   local CLONE_URL="$1"
   local CHECKOUT_REF="$2"
   local SSH_KEY_PATH="$3"
-  local CLONE_DIR
-  CLONE_DIR="$(get_repo_name "${CLONE_URL}")"
+  local CLONE_DIR="$4"
 
-  echo " :::: local clone location = $CLONE_DIR"
-  echo " :::: git remote url = $CLONE_URL"
-  echo " :::: ssh key path = $SSH_KEY_PATH"
+  echo " :::: local clone location = '$CLONE_DIR'"
+  echo " :::: git remote url = '$CLONE_URL'"
+  echo " :::: ssh key path = '$SSH_KEY_PATH'"
 
   if [[ -n "$SSH_KEY_PATH" ]]; then
     GIT_SSH_COMMAND="ssh -i $SSH_KEY_PATH -o IdentitiesOnly=yes"
     export GIT_SSH_COMMAND
   fi
 
-  cd "$WORKSPACE"
-  git clone --no-checkout "$CLONE_URL" && \
-    cd "$CLONE_DIR"
+  mkdir -p "${CLONE_DIR}" && cd "${CLONE_DIR}"
+  git clone --no-checkout "$CLONE_URL" .
   local EXIT_STATUS=$?
   if [[ $EXIT_STATUS -ne 0 ]]; then
     return $EXIT_STATUS
@@ -92,10 +90,12 @@ setup_git_repo() {
 CHECKED_OUT_REPO_NAME=""
 checkout_repo() {
   local config_prefix="$1"
+  local multiple_repos="$2"
   local index=0
 
   echo "--- :git: Checking out repository"
   while true; do
+    echo "$index"
     url="$(get_indirected_env "${config_prefix}_${index}_URL")"
     ref="$(get_indirected_env "${config_prefix}_${index}_REF")"
     ssh_key_path="$(get_indirected_env "${config_prefix}_${index}_SSH_KEY_PATH")"
@@ -103,7 +103,13 @@ checkout_repo() {
         exit 1
     fi
 
-    setup_git_repo "$url" "$ref" "$ssh_key_path"
+    if [[ "${MULTIPLE_REPOS}" == "true" ]]; then
+      clone_dir="$(get_repo_name "${url}")"
+    else
+      clone_dir="."
+    fi
+
+    setup_git_repo "$url" "$ref" "$ssh_key_path" "$clone_dir"
     EXIT_STATUS=$?
     if [[ $EXIT_STATUS -eq 0 ]]; then
       CHECKED_OUT_REPO_NAME="$(get_repo_name "$url")"
@@ -116,18 +122,20 @@ checkout_repo() {
 
 PLUGIN_PREFIX="BUILDKITE_PLUGIN_SMOOTH_CHECKOUT"
 
+MULTIPLE_REPOS="true"
+if [[ -z "$(get_indirected_env "${PLUGIN_PREFIX}_REPOS_1_CONFIG_0_URL")" ]]; then
+  MULTIPLE_REPOS="false"
+fi
+
 index=0
 while true; do
   config_prefix="${PLUGIN_PREFIX}_REPOS_${index}_CONFIG"
   if [[ -z "$(get_indirected_env "${config_prefix}_0_URL")" ]]; then
     break
   fi
-  checkout_repo "$config_prefix"
+  cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+  checkout_repo "$config_prefix" "${MULTIPLE_REPOS}"
   index=$((index+1))
 done
 
-if [[ "$index" -eq 1 ]]; then
-  cd "${WORKSPACE}/${CHECKED_OUT_REPO_NAME}"
-else
-  cd "$WORKSPACE"
-fi
+cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -63,7 +63,7 @@ setup_git_repo() {
     local EXIT_STATUS=$?
   else
     echo "Cloning ${REPO_URL}"
-    git clone ${BUILDKITE_GIT_CLONE_FLAGS} --no-checkout -- "$REPO_URL" .
+    git clone "${BUILDKITE_GIT_CLONE_FLAGS}" --no-checkout -- "$REPO_URL" .
     local EXIT_STATUS=$?
   fi
   if [[ $EXIT_STATUS -ne 0 ]]; then
@@ -94,7 +94,6 @@ setup_git_repo() {
   set -e
 }
 
-CHECKED_OUT_REPO_NAME=""
 checkout_repo() {
   local config_prefix="$1"
   local multiple_repos="$2"
@@ -110,19 +109,18 @@ checkout_repo() {
         exit 1
     fi
 
-    if [[ "${MULTIPLE_REPOS}" == "true" ]]; then
+    if [[ "${multiple_repos}" == "true" ]]; then
       clone_dir="$(get_repo_name "${url}")"
     else
       clone_dir="."
     fi
 
     setup_git_repo "$url" "$ref" "$ssh_key_path" "$clone_dir"
+
     EXIT_STATUS=$?
     if [[ $EXIT_STATUS -eq 0 ]]; then
-      CHECKED_OUT_REPO_NAME="$(get_repo_name "$url")"
       break
     fi
-
     index=$((index+=1))
   done
 }

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 
 function set_env() {
   local env_name=$1
@@ -10,6 +10,8 @@ function set_env() {
 }
 
 echo "--- :house_with_garden: Setting up environment"
-if [[ -v ${BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_BUILD_CHECKOUT_PATH} ]]; then
-  set_env BUILDKITE_BUILD_CHECKOUT_PATH "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_BUILD_CHECKOUT_PATH"
+if [[ -v BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_BUILD_CHECKOUT_PATH ]]; then
+  set_env BUILDKITE_BUILD_CHECKOUT_PATH "${BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_BUILD_CHECKOUT_PATH}"
+  # WORKSPACE is deprecated and preserved for backward compatibility.
+  set_env WORKSPACE "${BUILDKITE_BUILD_CHECKOUT_PATH}"
 fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -10,4 +10,6 @@ function set_env() {
 }
 
 echo "--- :house_with_garden: Setting up environment"
-set_env WORKSPACE "$HOME/buildkite-checkouts/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"
+if [[ -v ${BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_BUILD_CHECKOUT_PATH} ]]; then
+  set_env BUILDKITE_BUILD_CHECKOUT_PATH "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_BUILD_CHECKOUT_PATH"
+fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [[ "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_SKIP_CHECKOUT" == "true" \
-    || "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_DELETE_CHECKOUT" == "false" ]]; then
+    || "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_DELETE_CHECKOUT" != "true" ]]; then
   exit 0
 fi
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,17 +2,13 @@
 
 set -eo pipefail
 
-if [[ "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_SKIP_CHECKOUT" == "true" ]]; then
-    exit 0
+if [[ "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_SKIP_CHECKOUT" == "true" \
+    || "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_DELETE_CHECKOUT" == "false" ]]; then
+  exit 0
 fi
 
-echo "--- :broom: Cleaning up workspace"
-echo "Removing directory: $WORKSPACE/$CLONE_DIR"
-sudo rm -rf "$WORKSPACE/$CLONE_DIR"
-unset CLONE_DIR
-unset CLONE_URL
-
-echo "Removing workspace directory: $WORKSPACE"
-sudo rm -rf "$WORKSPACE"
-unset WORKSPACE
+echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
+# Only try sudo if deleting without sudo fails
+rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" \
+  || sudo rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
 echo "Cleanup completed successfully."

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,10 @@ configuration:
   properties:
     skip_checkout:
       type: boolean
+    build_checkout_path:
+      type: string
+    delete_checkout:
+      type: boolean
     repos:
       type: array
       items:


### PR DESCRIPTION
This changes the plugin to use `BUILDKITE_BUILD_CHECKOUT_PATH` by
default with the ability to specify another path. When only one repo is
checked out, it is checked out directly at the checkout path, as in the
Buildkite default checkout behavior. When multiple repos are checked
out, they are each in their own subdirectory under
`BUILDKITE_BUILD_CHECKOUT_PATH` with names determined by their URL.

I made use of this in my own project with
https://github.com/google/iree/pull/8619

Fixes https://github.com/hasura/smooth-checkout-buildkite-plugin/issues/13
Fixes https://github.com/hasura/smooth-checkout-buildkite-plugin/issues/21
Fixes https://github.com/hasura/smooth-checkout-buildkite-plugin/issues/22
Fixes https://github.com/hasura/smooth-checkout-buildkite-plugin/issues/23
