### PR TITLE
Add `depth` parameter to aid in shallow clones

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -51,7 +51,7 @@ setup_git_repo() {
   echo " :::: local clone location = '$CLONE_DIR'"
   echo " :::: git remote url = '$REPO_URL'"
   echo " :::: ssh key path = '$SSH_KEY_PATH'"
-  if [[ -z "${DEPTH_FLAG}" ]]; then
+  if [[ -n "${DEPTH_FLAG}" ]]; then
     echo " :::: depth flag = '${DEPTH_FLAG}'"
   fi
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -46,10 +46,14 @@ setup_git_repo() {
   local CHECKOUT_REF="$2"
   local SSH_KEY_PATH="$3"
   local CLONE_DIR="$4"
+  local DEPTH_FLAG="$5"
 
   echo " :::: local clone location = '$CLONE_DIR'"
   echo " :::: git remote url = '$REPO_URL'"
   echo " :::: ssh key path = '$SSH_KEY_PATH'"
+  if [[ -z "${DEPTH_FLAG}" ]]; then
+    echo " :::: depth flag = '${DEPTH_FLAG}'"
+  fi
 
   if [[ -n "$SSH_KEY_PATH" ]]; then
     GIT_SSH_COMMAND="ssh -i $SSH_KEY_PATH -o IdentitiesOnly=yes"
@@ -63,7 +67,7 @@ setup_git_repo() {
     local EXIT_STATUS=$?
   else
     echo "Cloning ${REPO_URL}"
-    git clone "${BUILDKITE_GIT_CLONE_FLAGS}" --no-checkout -- "$REPO_URL" .
+    git clone "${BUILDKITE_GIT_CLONE_FLAGS}" ${DEPTH_FLAG} --no-checkout -- "$REPO_URL" .
     local EXIT_STATUS=$?
   fi
   if [[ $EXIT_STATUS -ne 0 ]]; then
@@ -72,7 +76,7 @@ setup_git_repo() {
 
   if [ -z "${CHECKOUT_REF}" ]; then
     echo "Checking out branch: $BUILDKITE_BRANCH with $BUILDKITE_COMMIT"
-    git fetch --force origin "$BUILDKITE_BRANCH" && \
+    git fetch --force origin ${DEPTH_FLAG} "$BUILDKITE_BRANCH" && \
     git checkout --quiet --force "$BUILDKITE_BRANCH" && \
     git reset --hard "$BUILDKITE_COMMIT"
     local EXIT_STATUS=$?
@@ -81,7 +85,7 @@ setup_git_repo() {
     fi
   else
     echo "Checking out ref: $CHECKOUT_REF"
-    git fetch --force origin "$CHECKOUT_REF" && \
+    git fetch --force ${DEPTH_FLAG} origin "$CHECKOUT_REF" && \
     git checkout --quiet --force FETCH_HEAD
     local EXIT_STATUS=$?
     if [[ $EXIT_STATUS -ne 0 ]]; then
@@ -105,6 +109,7 @@ checkout_repo() {
     url="$(get_indirected_env "${config_prefix}_${index}_URL")"
     ref="$(get_indirected_env "${config_prefix}_${index}_REF")"
     ssh_key_path="$(get_indirected_env "${config_prefix}_${index}_SSH_KEY_PATH")"
+    depth="$(get_indirected_env "${config_prefix}_${index}_DEPTH")"
     if [ -z "${url}" ]; then
         exit 1
     fi
@@ -115,7 +120,12 @@ checkout_repo() {
       clone_dir="."
     fi
 
-    setup_git_repo "$url" "$ref" "$ssh_key_path" "$clone_dir"
+    depth_flag=""
+    if [[ -n "${depth}" ]]; then
+      depth_flag="--depth ${depth}"
+    fi
+
+    setup_git_repo "$url" "$ref" "$ssh_key_path" "$clone_dir" "$depth_flag"
 
     EXIT_STATUS=$?
     if [[ $EXIT_STATUS -eq 0 ]]; then

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -76,7 +76,7 @@ setup_git_repo() {
 
   if [ -z "${CHECKOUT_REF}" ]; then
     echo "Checking out branch: $BUILDKITE_BRANCH with $BUILDKITE_COMMIT"
-    git fetch --force origin ${DEPTH_FLAG} "$BUILDKITE_BRANCH" && \
+    git fetch --force ${DEPTH_FLAG} origin "$BUILDKITE_BRANCH" && \
     git checkout --quiet --force "$BUILDKITE_BRANCH" && \
     git reset --hard "$BUILDKITE_COMMIT"
     local EXIT_STATUS=$?

--- a/plugin.yml
+++ b/plugin.yml
@@ -26,6 +26,8 @@ configuration:
                   type: string
                 ssh_key_path:
                   type: string
+                depth:
+                  type: number
               additionalProperties: false
             required:
               - url


### PR DESCRIPTION
This adds a `depth` parameter, which can be used to pass `--depth`
arguments to `git clone`, vastly reducing network traffic when a full
clone is not necessary.