### PR TITLE
checkout out to CHECKOUT_REF instead of FETCH_HEAD

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -48,6 +48,7 @@ setup_git_repo() {
   local CLONE_DIR="$4"
 
   echo " :::: local clone location = '$CLONE_DIR'"
+  echo " :::: checkout ref = '$CHECKOUT_REF'"
   echo " :::: git remote url = '$REPO_URL'"
   echo " :::: ssh key path = '$SSH_KEY_PATH'"
 
@@ -84,7 +85,7 @@ setup_git_repo() {
   else
     echo "Checking out ref: $CHECKOUT_REF"
     git fetch --force origin "$CHECKOUT_REF" && \
-    git checkout --quiet --force FETCH_HEAD
+    git checkout --quiet --force "$CHECKOUT_REF"
     local EXIT_STATUS=$?
     if [[ $EXIT_STATUS -ne 0 ]]; then
       return $EXIT_STATUS


### PR DESCRIPTION
Our documentation states that three kinds of values are possible for `ref` option.

![image](https://user-images.githubusercontent.com/4211715/202219579-030368e4-d749-4e38-a4b9-c26acef16e61.png)

From `v4.0.0`, we started checking out to FETCH_HEAD instead of CHECKOUT_REF ([reference](https://github.com/hasura/smooth-checkout-buildkite-plugin/pull/25/files#diff-d51517d4f0a9a3cd5d9b40ed243c371e9f4ab3a30a95d0fdc09400d753163152L80-R85))

This is okay when `ref` is a commit or tag. Because both are readonly and a user using them in their builds don't intend to do a `git push` in those cases. But when a `ref` is pointing to a branch name, then the user might be intending to do a `git push` to that branch at some point in their build. Using the FETCH_HEAD instead of CHECKOUT_REF causes the repo to be in detached HEAD state which will not allow a git push. This PR addresses this particular regression when `ref` is pointing to a branch name.