### PR TITLE
avoids cleanup logging and introduces `clone_flags` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ steps:
           repos:
             - config:
               - url: git@github.com:<username>/<reponame>.git
-                ref: <ref>
+                ref: <ref> # (optional)
+                clone_flags: <flags> # (optional) flags to use with `git clone` command
 ```
 
 If `ref` is not provided the values of `BUILDKITE_BRANCH` and `BUILDKITE_COMMIT` env vars are used.

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -46,11 +46,13 @@ setup_git_repo() {
   local CHECKOUT_REF="$2"
   local SSH_KEY_PATH="$3"
   local CLONE_DIR="$4"
+  local CLONE_FLAGS="$5"
 
   echo " :::: local clone location = '$CLONE_DIR'"
   echo " :::: checkout ref = '$CHECKOUT_REF'"
   echo " :::: git remote url = '$REPO_URL'"
   echo " :::: ssh key path = '$SSH_KEY_PATH'"
+  echo " :::: clone flags = '$CLONE_FLAGS'"
 
   if [[ -n "$SSH_KEY_PATH" ]]; then
     GIT_SSH_COMMAND="ssh -i $SSH_KEY_PATH -o IdentitiesOnly=yes"
@@ -66,7 +68,7 @@ setup_git_repo() {
     local EXIT_STATUS=$?
   else
     echo "Cloning ${REPO_URL}"
-    git clone "${BUILDKITE_GIT_CLONE_FLAGS}" --no-checkout -- "$REPO_URL" .
+    git clone "${BUILDKITE_GIT_CLONE_FLAGS}" "${CLONE_FLAGS}" --no-checkout -- "$REPO_URL" .
     local EXIT_STATUS=$?
   fi
   if [[ $EXIT_STATUS -ne 0 ]]; then
@@ -108,6 +110,7 @@ checkout_repo() {
     url="$(get_indirected_env "${config_prefix}_${index}_URL")"
     ref="$(get_indirected_env "${config_prefix}_${index}_REF")"
     ssh_key_path="$(get_indirected_env "${config_prefix}_${index}_SSH_KEY_PATH")"
+    clone_flags="$(get_indirected_env "${config_prefix}_${index}_CLONE_FLAGS")"
     if [ -z "${url}" ]; then
         exit 1
     fi
@@ -118,7 +121,7 @@ checkout_repo() {
       clone_dir="."
     fi
 
-    setup_git_repo "$url" "$ref" "$ssh_key_path" "$clone_dir"
+    setup_git_repo "$url" "$ref" "$ssh_key_path" "$clone_dir" "$clone_flags"
 
     EXIT_STATUS=$?
     if [[ $EXIT_STATUS -eq 0 ]]; then

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -9,6 +9,6 @@ fi
 
 echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
 # Only try sudo if deleting without sudo fails
-rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" \
+rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null \
   || sudo rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
 echo "Cleanup completed successfully."

--- a/plugin.yml
+++ b/plugin.yml
@@ -26,6 +26,8 @@ configuration:
                   type: string
                 ssh_key_path:
                   type: string
+                clone_flags:
+                  type: string
               additionalProperties: false
             required:
               - url


### PR DESCRIPTION
fixes https://github.com/hasura/smooth-checkout-buildkite-plugin/issues/31

#### Avoiding cleanup logs
Having `delete_checkout` option set to true, will try to remove the checkout directory files as a normal user and via sudo if faced with errors as a normal user. If there are huge number of files to be deleted and if the normal user doesn't have permissions to delete them, then we might encounter a lot of log lines in buildkite logs due to this which would be noise, because the sudo remove would most probably succeed after that.

Hence, starting from this release we default to not show the errors of `rm -rf` while running it as normal user.

#### `clone_flags` option
We now have `clone_flags` option as part of the config, which could be used to pass the command line flags that will be used while doing `git clone` in the smooth checkout plugin.

```yml
steps:
  - command: echo "Checks out repo at given ref"
    plugins:
      - hasura/smooth-checkout#v3.1.0:
          repos:
            - config:
              - url: git@github.com:<username>/<reponame>.git
                ref: <ref> # (optional)
                clone_flags: <flags> # (optional) flags to use with `git clone` command
```