### PR TITLE
allow proper word splitting when using clone flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All the things you need during a Buildkite checkout :butter: :kite:
 steps:
   - command: echo "Skips checking out Git project in checkout"
     plugins:
-      - hasura/smooth-checkout#v4.1.0:
+      - hasura/smooth-checkout#v4.1.1:
           skip_checkout: true
 ```
 
@@ -17,7 +17,7 @@ steps:
 steps:
   - command: echo "Checks out repo at given ref"
     plugins:
-      - hasura/smooth-checkout#v4.1.0:
+      - hasura/smooth-checkout#v4.1.1:
           repos:
             - config:
               - url: git@github.com:<username>/<reponame>.git
@@ -52,7 +52,7 @@ You can checkout multiple repositories by providing multiple `config` elements:
 steps:
   - command: echo "Checks out multiple git repositories"
     plugins:
-      - hasura/smooth-checkout#v4.1.0:
+      - hasura/smooth-checkout#v4.1.1:
           repos:
             - config:
               - url: git@github.com:<username>/<repo_1>.git
@@ -70,7 +70,7 @@ You can also explicitly provide the path to an ssh identity file using the `ssh_
 steps:
   - command: echo "Checks out multiple git repositories"
     plugins:
-      - hasura/smooth-checkout#v4.1.0:
+      - hasura/smooth-checkout#v4.1.1:
           repos:
             - config:
               - url: git@github.com:<username>/<repo_1>.git
@@ -87,7 +87,7 @@ configure ssh keys, you can do the following to easily set the `ssh_key_path`:
 steps:
   - command: echo "Checks out multiple git repositories"
     plugins:
-      - hasura/smooth-checkout#v4.1.0:
+      - hasura/smooth-checkout#v4.1.1:
           repos:
             - config:
               - url: git@github.com:<username>/<repo>.git
@@ -104,7 +104,7 @@ source repo in case of a failure while checking out from mirrors.
 steps:
   - command: echo "Checks out repo from mirror (fall back to github in case of failure)"
     plugins:
-      - hasura/smooth-checkout#v4.1.0:
+      - hasura/smooth-checkout#v4.1.1:
           repos:
             - config:
               - url: git@mirror.git.interal:/path/to/git/mirror
@@ -121,7 +121,7 @@ variable `WORKSPACE` is also set to the same value, but its usage is deprecated.
 steps:
   - command: echo "Checks out repo to custom directory"
     plugins:
-      - hasura/smooth-checkout#v4.1.0:
+      - hasura/smooth-checkout#v4.1.1:
           build_checkout_path: /tmp/${BUILDKITE_COMMIT}
           delete_checkout: true
           repos:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All the things you need during a Buildkite checkout :butter: :kite:
 steps:
   - command: echo "Skips checking out Git project in checkout"
     plugins:
-      - hasura/smooth-checkout#v3.1.0:
+      - hasura/smooth-checkout#v4.1.0:
           skip_checkout: true
 ```
 
@@ -17,7 +17,7 @@ steps:
 steps:
   - command: echo "Checks out repo at given ref"
     plugins:
-      - hasura/smooth-checkout#v3.1.0:
+      - hasura/smooth-checkout#v4.1.0:
           repos:
             - config:
               - url: git@github.com:<username>/<reponame>.git
@@ -32,13 +32,27 @@ Allowed values for `ref`:
 - Git tag
 - Commit SHA (40 character long hash)
 
+### Shallow clone
+A shallow clone can easily be done by passing the `depth` flag in the `clone_flags` field. For example:
+```yaml
+steps:
+  - command: echo "shallow clone repo"
+    plugins:
+      - hasura/smooth-checkout#v4.1.1:
+          repos:
+            - config:
+                - url: "git@github.com:hasura/smooth-checkout-buildkite-plugin"
+                  clone_flags: "--depth 1"
+```
+      
+
 ### Checking out multiple repositories
 You can checkout multiple repositories by providing multiple `config` elements:
 ```yaml
 steps:
   - command: echo "Checks out multiple git repositories"
     plugins:
-      - hasura/smooth-checkout#v3.1.0:
+      - hasura/smooth-checkout#v4.1.0:
           repos:
             - config:
               - url: git@github.com:<username>/<repo_1>.git
@@ -56,7 +70,7 @@ You can also explicitly provide the path to an ssh identity file using the `ssh_
 steps:
   - command: echo "Checks out multiple git repositories"
     plugins:
-      - hasura/smooth-checkout#v3.1.0:
+      - hasura/smooth-checkout#v4.1.0:
           repos:
             - config:
               - url: git@github.com:<username>/<repo_1>.git
@@ -73,7 +87,7 @@ configure ssh keys, you can do the following to easily set the `ssh_key_path`:
 steps:
   - command: echo "Checks out multiple git repositories"
     plugins:
-      - hasura/smooth-checkout#v3.1.0:
+      - hasura/smooth-checkout#v4.1.0:
           repos:
             - config:
               - url: git@github.com:<username>/<repo>.git
@@ -90,7 +104,7 @@ source repo in case of a failure while checking out from mirrors.
 steps:
   - command: echo "Checks out repo from mirror (fall back to github in case of failure)"
     plugins:
-      - hasura/smooth-checkout#v3.1.0:
+      - hasura/smooth-checkout#v4.1.0:
           repos:
             - config:
               - url: git@mirror.git.interal:/path/to/git/mirror
@@ -107,7 +121,7 @@ variable `WORKSPACE` is also set to the same value, but its usage is deprecated.
 steps:
   - command: echo "Checks out repo to custom directory"
     plugins:
-      - hasura/smooth-checkout#v3.1.0:
+      - hasura/smooth-checkout#v4.1.0:
           build_checkout_path: /tmp/${BUILDKITE_COMMIT}
           delete_checkout: true
           repos:

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -68,6 +68,7 @@ setup_git_repo() {
     local EXIT_STATUS=$?
   else
     echo "Cloning ${REPO_URL}"
+    # shellcheck disable=SC2086
     git clone ${BUILDKITE_GIT_CLONE_FLAGS} ${CLONE_FLAGS} --no-checkout -- "$REPO_URL" .
     local EXIT_STATUS=$?
   fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -68,7 +68,7 @@ setup_git_repo() {
     local EXIT_STATUS=$?
   else
     echo "Cloning ${REPO_URL}"
-    git clone "${BUILDKITE_GIT_CLONE_FLAGS}" "${CLONE_FLAGS}" --no-checkout -- "$REPO_URL" .
+    git clone ${BUILDKITE_GIT_CLONE_FLAGS} ${CLONE_FLAGS} --no-checkout -- "$REPO_URL" .
     local EXIT_STATUS=$?
   fi
   if [[ $EXIT_STATUS -ne 0 ]]; then


### PR DESCRIPTION
removes double quotes around `CLONE_FLAGS` and `BUILDKITE_GIT_CLONE_FLAGS` so that proper word splitting can happen. It's not possible to pass multiple flags with double quotes, because the whole string is taken as one single value.

For example, passing  `--depth=1 --filter=blob:none` was raising this error
![Screenshot from 2022-11-21 18-12-39](https://user-images.githubusercontent.com/32202683/203058282-46e23a42-801c-4a7d-8e9d-55f2689888c5.png)

Also, adds a shallow clone example to the README 