### PR TITLE
pin buildkite/plugin-tester image version to v3.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     volumes:
       - .:/plugin:ro
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
-      - .:/plugin:ro
+      - ".:/plugin"


### PR DESCRIPTION
Test file in smooth-checkout-buildkite-plugin repo was failing (even when no code changes are made in the PR): https://github.com/hasura/smooth-checkout-buildkite-plugin/actions/runs/4363201542/jobs/7629010128
```
-- command failed --
# status : 1
# output (5 lines):
#   --- :open_file_folder: Setting up workspace
#   Creating directory: /root/repo
#   Setup completed successfully.
#   --- :key: Setting up git and ssh
#   github.com not found in known_hosts
# --
```
Currently, "bats" testing framework is covered by buildkite. 

This PR pins buildkite/plugin-tester image version to v3.0.1
