### PR TITLE
checkout using BUILDKITE_TAG if set

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -76,25 +76,25 @@ setup_git_repo() {
     return $EXIT_STATUS
   fi
 
-  if [ -z "${CHECKOUT_REF}" ]; then
+  if [ -n "${BUILDKITE_TAG}" ]; then
+    echo "Checking out tag: ${BUILDKITE_TAG}"
+    git fetch --force origin "${BUILDKITE_TAG}" && \
+      git checkout --quite --force "${BUILDKITE_TAG}"
+  elif [ -z "${CHECKOUT_REF}" ]; then
     echo "Checking out branch: $BUILDKITE_BRANCH with $BUILDKITE_COMMIT"
     git fetch --force origin "$BUILDKITE_BRANCH" && \
-    git checkout --quiet --force "$BUILDKITE_BRANCH" && \
-    git reset --hard "$BUILDKITE_COMMIT"
-    local EXIT_STATUS=$?
-    if [[ $EXIT_STATUS -ne 0 ]]; then
-      return $EXIT_STATUS
-    fi
+      git checkout --quiet --force "$BUILDKITE_BRANCH" && \
+      git reset --hard "$BUILDKITE_COMMIT"
   else
     echo "Checking out ref: $CHECKOUT_REF"
     git fetch --force origin "$CHECKOUT_REF" && \
     git checkout --quiet --force "$CHECKOUT_REF"
-    local EXIT_STATUS=$?
-    if [[ $EXIT_STATUS -ne 0 ]]; then
-      return $EXIT_STATUS
-    fi
   fi
+  local EXIT_STATUS=$?
   unset GIT_SSH_COMAND
+  if [[ $EXIT_STATUS -ne 0 ]]; then
+    return $EXIT_STATUS
+  fi
 
   git log -n 1 --format="Repo checked out at %h %s"
   set -e

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -63,8 +63,8 @@ setup_git_repo() {
   if [[ -d ".git" ]]; then
     echo "Git repository already exists."
     echo "So, doing a git clean and setting the remote URL"
-    sudo git clean -fdqx || \
-      git clean -fdqx && \
+    git clean -fdqx || \
+      sudo git clean -fdqx && \
       git remote set-url origin "${REPO_URL}"
     local EXIT_STATUS=$?
   else

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -63,8 +63,9 @@ setup_git_repo() {
   if [[ -d ".git" ]]; then
     echo "Git repository already exists."
     echo "So, doing a git clean and setting the remote URL"
-    sudo git clean -fdqx && \
-    git remote set-url origin "${REPO_URL}"
+    sudo git clean -fdqx || \
+      git clean -fdqx && \
+      git remote set-url origin "${REPO_URL}"
     local EXIT_STATUS=$?
   else
     echo "Cloning ${REPO_URL}"
@@ -88,7 +89,7 @@ setup_git_repo() {
   else
     echo "Checking out ref: $CHECKOUT_REF"
     git fetch --force origin "$CHECKOUT_REF" && \
-    git checkout --quiet --force "$CHECKOUT_REF"
+      git checkout --quiet --force "$CHECKOUT_REF"
   fi
   local EXIT_STATUS=$?
   unset GIT_SSH_COMAND

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -80,7 +80,7 @@ setup_git_repo() {
   if [ -n "${BUILDKITE_TAG}" ]; then
     echo "Checking out tag: ${BUILDKITE_TAG}"
     git fetch --force origin "${BUILDKITE_TAG}" && \
-      git checkout --quite --force "${BUILDKITE_TAG}"
+      git checkout --quiet --force "${BUILDKITE_TAG}"
   elif [ -z "${CHECKOUT_REF}" ]; then
     echo "Checking out branch: $BUILDKITE_BRANCH with $BUILDKITE_COMMIT"
     git fetch --force origin "$BUILDKITE_BRANCH" && \


### PR DESCRIPTION
if `BUILDKITE_TAG` is set, the plugin will use that tag to checkout the repo. `BUILDKITE_TAG` takes precedence over the `ref` config option.