### PR TITLE
refactor cleanup section to avoid 'stop the world' sudo command

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -9,7 +9,11 @@ fi
 
 echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
 
+echo "before rm -rf of $BUILDKITE_BUILD_CHECKOUT_PATH"
+
 rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" || true
+
+echo "after rm -rf of $BUILDKITE_BUILD_CHECKOUT_PATH"
 
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
@@ -17,13 +21,19 @@ if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   ls -la $BUILDKITE_BUILD_CHECKOUT_PATH
 fi
 
+echo "after first check"
+
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo "Trying to cleanup $BUILDKITE_BUILD_CHECKOUT_PATH using sudo"
   sudo -n rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
 fi
+
+echo "after second check"
 
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo "Cleanup was not successful."
 else
   echo "Cleanup completed successfully."
 fi
+
+echo "finally"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -8,7 +8,20 @@ if [[ "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_SKIP_CHECKOUT" == "true" \
 fi
 
 echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
-# Only try sudo if deleting without sudo fails
-rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null \
-  || sudo rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
-echo "Cleanup completed successfully."
+
+rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
+  echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
+  echo "But it failed leaving the following files as residue"
+  ls -la $BUILDKITE_BUILD_CHECKOUT_PATH
+}
+
+if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
+  echo "Trying to cleanup $BUILDKITE_BUILD_CHECKOUT_PATH using sudo"
+  sudo -n rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
+fi
+
+if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
+  echo "Cleanup was not successful."
+else
+  echo "Cleanup completed successfully."
+fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -8,32 +8,27 @@ if [[ "$BUILDKITE_PLUGIN_SMOOTH_CHECKOUT_SKIP_CHECKOUT" == "true" \
 fi
 
 echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
-
-echo "before rm -rf of $BUILDKITE_BUILD_CHECKOUT_PATH"
-
-rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" || true
-
-echo "after rm -rf of $BUILDKITE_BUILD_CHECKOUT_PATH"
-
-if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
+# redirecting rm's stderr to /dev/null
+# because it would pollute the logs if there were a lot of files inside the folder to be removed.
+# Example: `node_modules` folder created by a different user in a container during a build throwing
+# permission error for each of the files inside it.
+rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
   echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
   echo "But it failed leaving the following files as residue"
-  ls -la $BUILDKITE_BUILD_CHECKOUT_PATH
-fi
-
-echo "after first check"
+  ls -la "$BUILDKITE_BUILD_CHECKOUT_PATH"
+}
 
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
-  echo "Trying to cleanup $BUILDKITE_BUILD_CHECKOUT_PATH using sudo"
-  sudo -n rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
+  echo echo "Attempting to cleanup with sudo"
+  sudo -n rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" || {
+    echo "Tried running: sudo -n rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
+    echo "But it failed leaving the following files as residue"
+    ls -la "$BUILDKITE_BUILD_CHECKOUT_PATH"
+  }
 fi
 
-echo "after second check"
-
-if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
-  echo "Cleanup was not successful."
-else
+if [ ! -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo "Cleanup completed successfully."
+else
+  echo "Cleanup was not successful."
 fi
-
-echo "finally"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -9,11 +9,13 @@ fi
 
 echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
 
-rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
+rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" || true
+
+if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
   echo "But it failed leaving the following files as residue"
   ls -la $BUILDKITE_BUILD_CHECKOUT_PATH
-}
+fi
 
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo "Trying to cleanup $BUILDKITE_BUILD_CHECKOUT_PATH using sudo"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -19,7 +19,7 @@ rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
 }
 
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
-  echo echo "Attempting to cleanup with sudo"
+  echo "Attempting to cleanup with sudo"
   sudo -n rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" || {
     echo "Tried running: sudo -n rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
     echo "But it failed leaving the following files as residue"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -12,11 +12,11 @@ echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
 # because it would pollute the logs if there were a lot of files inside the folder to be removed.
 # Example: `node_modules` folder created by a different user in a container during a build throwing
 # permission error for each of the files inside it.
-# rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
-#   echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
-#   echo "But it failed leaving the following files as residue"
-#   ls -la "$BUILDKITE_BUILD_CHECKOUT_PATH"
-# }
+rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
+  echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
+  echo "But it failed leaving the following files as residue"
+  ls -la "$BUILDKITE_BUILD_CHECKOUT_PATH"
+}
 
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo echo "Attempting to cleanup with sudo"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -12,11 +12,11 @@ echo "Removing checkout directory: $BUILDKITE_BUILD_CHECKOUT_PATH"
 # because it would pollute the logs if there were a lot of files inside the folder to be removed.
 # Example: `node_modules` folder created by a different user in a container during a build throwing
 # permission error for each of the files inside it.
-rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
-  echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
-  echo "But it failed leaving the following files as residue"
-  ls -la "$BUILDKITE_BUILD_CHECKOUT_PATH"
-}
+# rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH" 2>/dev/null || {
+#   echo "Tried running: rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH"
+#   echo "But it failed leaving the following files as residue"
+#   ls -la "$BUILDKITE_BUILD_CHECKOUT_PATH"
+# }
 
 if [ -d "$BUILDKITE_BUILD_CHECKOUT_PATH" ]; then
   echo echo "Attempting to cleanup with sudo"


### PR DESCRIPTION
There are cases where the build gets stuck forever waiting for password while trying to do sudo rm -rf in the clean up section

![image](https://github.com/hasura/smooth-checkout-buildkite-plugin/assets/4211715/7dc9dc01-930a-44e3-a635-a076e649d5ee)

This PR tries to avoid such cases.